### PR TITLE
Enable JIT option in fastify-gql

### DIFF
--- a/frameworks/fastify-gql/app.js
+++ b/frameworks/fastify-gql/app.js
@@ -84,7 +84,7 @@ if (!app.hasContentTypeParser('application/graphql')) {
 
 app
   .get('/', (request, reply) => reply.send())
-  .register(fastifyGQL, { schema, resolvers, graphiql: false })
+  .register(fastifyGQL, { schema, resolvers, graphiql: false, jit: 1 })
   .listen(3000, '0.0.0.0')
   .then((address) => console.log(`GraphQL API server is listening at ${address}/graphql`))
   .catch(err => {


### PR DESCRIPTION
One of the main value propositions of the fastify-gql framework is the built-in graphql-jit support. It's turned off by default (for some reason).

On my laptop this change increased the rate by about 33%, but I imagine it may be more on a faster computer.