### PR TITLE
Update dependencies and refactor code for new version

### DIFF
--- a/frameworks/fastify-gql/app.js
+++ b/frameworks/fastify-gql/app.js
@@ -68,20 +68,6 @@ const resolvers = {
   }
 }
 
-// fastify and fastify-gql do not support application/graphql parser
-if (!app.hasContentTypeParser('application/graphql')) {
-  app.addContentTypeParser('application/graphql', function (req, done) {
-    var body = ''
-    req.on('data', function (data) {
-      body += data
-    })
-    req.on('end', function () {
-      done(null, { query: body.replace('=', ' ') })
-    })
-    req.on('error', done)
-  })
-}
-
 app
   .get('/', (request, reply) => reply.send())
   .register(fastifyGQL, { schema, resolvers, graphiql: false, jit: 1 })

--- a/frameworks/fastify-gql/package.json
+++ b/frameworks/fastify-gql/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"fastify": "^2.10.0",
-		"fastify-gql": "^2.0.2"
+		"fastify": "^2.11.0",
+		"fastify-gql": "^3.0.0"
 	}
 }


### PR DESCRIPTION
fastify-gql from version 3.0.0 supports application/graphql content-type. Special handling was removed from app.js to make code more verbose.